### PR TITLE
fix: fetch stat from index instead of computing again

### DIFF
--- a/src/database/tree.rs
+++ b/src/database/tree.rs
@@ -93,8 +93,8 @@ impl Storable for Tree {
                 FileOrTree::File(entry) => {
                     let mut output: Vec<&[u8]> = Vec::new();
 
-                    let stat = fs::metadata(&entry.path).expect("Failed to get file metadata");
-                    let is_executable = stat.permissions().mode() & 0o111 != 0;
+                    let stat = entry.stat.clone();
+                    let is_executable = stat.mode & 0o111 != 0;
                     if is_executable {
                         output.push("100755".as_bytes());
                     } else {


### PR DESCRIPTION
Fetches stat from index tree instead of computing again while constructing commit tree. This solves deleting a file and commit it after it has been added to index area.

```base
rgit init

rgit add .

rm file.txt 

rgit commit -m "initial commit" // this would error out "file not found" before this
```